### PR TITLE
Make TLS optional

### DIFF
--- a/charts/bitwarden/templates/certificate.yaml
+++ b/charts/bitwarden/templates/certificate.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if and .Values.ingress.enabled .Values.ingress.tls.enabled -}}
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:

--- a/charts/bitwarden/templates/ingress.yaml
+++ b/charts/bitwarden/templates/ingress.yaml
@@ -16,10 +16,12 @@ metadata:
     kubernetes.io/ingress.class: {{ .Values.ingress.class | quote }}
 {{- end }}
 spec:
+{{- if .Values.ingress.tls.enabled -}}
   tls:
     - hosts:
         - {{ .Values.global.host | quote }}
       secretName: {{ include "bitwarden.fullname" . }}-nginx-tls
+{{- end }}
   rules:
     - host: {{ .Values.global.host | quote }}
       http:

--- a/charts/bitwarden/values.yaml
+++ b/charts/bitwarden/values.yaml
@@ -235,6 +235,8 @@ ingress:
   enabled: true
   ip: ~
   class: ~
+  tls:
+    enabled: true
 
 certificates:
   issuer: letsencrypt-prod


### PR DESCRIPTION
My cluster runs Traefik (instead of nginx), which solves all my TLS needs. In order to use your chart, I need this patch to get it to work. Maybe you could integrate this into yours, so I don't have to keep a fork?