### PR TITLE
Fix deprecation of policy/v1beta

### DIFF
--- a/charts/bitwarden/Chart.yaml
+++ b/charts/bitwarden/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: bitwarden
-version: 0.1.0
+version: 0.1.1

--- a/charts/bitwarden/templates/core/pdb.yaml
+++ b/charts/bitwarden/templates/core/pdb.yaml
@@ -1,6 +1,10 @@
 {{- if or .Values.attachments.enabled .Values.api.enabled .Values.admin.enabled .Values.identity.enabled }}
 {{- if and .Values.global.pdb .Values.core.pdb.enabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "bitwarden.fullname" . }}-core

--- a/charts/bitwarden/templates/icons/pdb.yaml
+++ b/charts/bitwarden/templates/icons/pdb.yaml
@@ -1,5 +1,9 @@
 {{- if and .Values.icons.enabled .Values.icons.pdb.enabled .Values.global.pdb }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "bitwarden.fullname" . }}-icons

--- a/charts/bitwarden/templates/mssql/pdb.yaml
+++ b/charts/bitwarden/templates/mssql/pdb.yaml
@@ -1,5 +1,9 @@
 {{- if and .Values.mssql.enabled .Values.mssql.pdb.enabled .Values.global.pdb }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "bitwarden.fullname" . }}-mssql

--- a/charts/bitwarden/templates/nginx/pdb.yaml
+++ b/charts/bitwarden/templates/nginx/pdb.yaml
@@ -1,5 +1,9 @@
 {{- if and .Values.nginx.enabled .Values.nginx.pdb.enabled .Values.global.pdb }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "bitwarden.fullname" . }}-nginx

--- a/charts/bitwarden/templates/notifications/pdb.yaml
+++ b/charts/bitwarden/templates/notifications/pdb.yaml
@@ -1,5 +1,9 @@
 {{- if and .Values.notifications.enabled .Values.notifications.pdb.enabled .Values.global.pdb }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "bitwarden.fullname" . }}-notifications

--- a/charts/bitwarden/templates/web/pdb.yaml
+++ b/charts/bitwarden/templates/web/pdb.yaml
@@ -1,5 +1,9 @@
 {{- if and .Values.web.enabled .Values.web.pdb.enabled .Values.global.pdb }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "bitwarden.fullname" . }}-web


### PR DESCRIPTION
```
policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
```

Change dynamically chooses correct apiVersion for PodDisruptionBudget
based on capabilities available in the cluster.

Fixes #8 