### PR TITLE
Fix missing cert-manager api-version.

### DIFF
--- a/charts/bitwarden/Chart.yaml
+++ b/charts/bitwarden/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: bitwarden
-version: 0.1.0
+version: 0.1.2

--- a/charts/bitwarden/templates/certificate.yaml
+++ b/charts/bitwarden/templates/certificate.yaml
@@ -1,5 +1,9 @@
 {{- if and .Values.ingress.enabled .Values.certificates.enabled -}}
+{{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
+apiVersion: cert-manager.io/v1
+{{- else }}
 apiVersion: cert-manager.io/v1alpha2
+{{- end }}
 kind: Certificate
 metadata:
   name: {{ include "bitwarden.fullname" . }}-nginx


### PR DESCRIPTION
Fixes the following error.

```
Error: unable to build kubernetes objects from release manifest: unable to recognize "": no matches for kind "Certificate" in version "cert-manager.io/v1alpha2
```
Fixes #10 