### PR TITLE
Add external hostname for sql server

### DIFF
--- a/charts/bitwarden/Chart.yaml
+++ b/charts/bitwarden/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: bitwarden
-version: 0.1.0
+version: 0.1.3

--- a/charts/bitwarden/templates/mssql/secret.yaml
+++ b/charts/bitwarden/templates/mssql/secret.yaml
@@ -1,6 +1,7 @@
 {{- if or .Values.mssql.enabled .Values.attachments.enabled .Values.api.enabled .Values.admin.enabled .Values.identity.enabled .Values.notifications.enabled }}
 {{ $fullName :=  include "bitwarden.fullname" . }}
-{{ $connectionString := (printf "\"Data Source=tcp:%s-mssql,1433;Initial Catalog=vault;Persist Security Info=False;User ID=sa;Password=%s;MultipleActiveResultSets=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=True\"" $fullName .Values.mssql.saPassword) }}
+{{ $serviceName := printf "%s-mssql" (include "bitwarden.fullname" .) }}
+{{ $connectionString := (printf "\"Data Source=tcp:%s,1433;Initial Catalog=vault;Persist Security Info=False;User ID=sa;Password=%s;MultipleActiveResultSets=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=True\"" (.Values.mssql.externalHostname | default $serviceName ) .Values.mssql.saPassword) }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
Adds ability to point chart at a MSSQL Server that is either externally hosted
or hosted in a separate namespace.

Fixes #12